### PR TITLE
Adjust SvcParamKeys

### DIFF
--- a/draft-dnsop-deleg.md
+++ b/draft-dnsop-deleg.md
@@ -282,10 +282,10 @@ As a special case, the presentation value "disabled", corresponding to an empty 
 
 To avoid a circular dependency, "tlsa" MUST appear in any DELEG record that is used to serve its own TargetName.
 
-Resolvers MUST adopt one of the following behaviors:
+Resolvers that support TLS-based transports MUST adopt one of the following behaviors:
 
 1. Use DANE for authentication, and treat any endpoints lacking DANE support as incompatible.
-1. Use PKI for authentication, and treat any DANE-only endpoint as incompatible.  Compatibility with `tlsa=disabled` endpoints is REQUIRED.
+1. Use PKI for authentication, and treat any DANE-only endpoint as incompatible.  In this behavior, compatibility with `tlsa=disabled` endpoints is REQUIRED.
 1. Support both DANE and PKI for authentication, preferring DANE if it is available for each endpoint.
 
 This SvcParamKey MAY be used in any SVCB context where TLSA usage is defined.
@@ -293,6 +293,11 @@ This SvcParamKey MAY be used in any SVCB context where TLSA usage is defined.
 ~~~
 ;; The server is only authenticatable via DANE.  Any resolver that
 ;; lacks DANE support will treat this record as incompatible.
+alpn=doq tlsa="..." mandatory=alpn
+
+;; The server is only authenticatable via DANE, but also offers Do53
+;; services.  All resolvers can access it, but only resolvers with
+;; DANE support will use DoQ.
 alpn=doq tlsa="..."
 
 ;; The server is authenticatable via PKI.  If TLSA records exist at
@@ -302,7 +307,7 @@ alpn=doq
 
 ;; The server is only authenticatable via PKI.  Any resolver that
 ;; lacks PKI validation support will treat this record as incompatible.
-alpn=doq tlsa=disabled
+alpn=doq tlsa=disabled mandatory=alpn
 ~~~
 {: title="tlsa SvcParam Examples for DELEG"}
 

--- a/draft-dnsop-deleg.md
+++ b/draft-dnsop-deleg.md
@@ -286,11 +286,13 @@ This SvcParam is "automatically mandatory" (i.e. non-ignorable) in DELEG, and it
 
 The "ds" SvcParamKey is a delegation parameter representing a DS RRset.  For usage notes, see {{dnssec}}.
 
-The SvcParamValue is a value-list.  The presentation and wire format of each value is the same as the presentation and wire format described for the DS record as defined in {{?RFC4034}}, sections 5.3 and 5.1 respectively.
+The SvcParamValue is a value-list.  The presentation and wire format of each value is the same as the presentation and wire format described for the DS record as defined in {{?RFC4034}}, sections 5.3 and 5.1 respectively.  When computing the digest, the DNSKEY Owner Name is always set to "." (i.e., the root), because this DS record approves the use of the specified DNSKEY on any zone that is delegated to this endpoint.
 
 If the "ds" SvcParamKey is omitted, the applicable DS RRset is the one that is present at the zone cut, if any.
 
 As a special case, the presentation value "disabled", corresponding to an empty value in wire format, indicates that there is no DS RRset for resolution to this delegated endpoint, even if a DS RRset is present at the zone cut.
+
+This SvcParam is "automatically mandatory" (i.e. non-ignorable) in DELEG for validating resolvers.
 
 ## Deployment Considerations
 

--- a/draft-dnsop-deleg.md
+++ b/draft-dnsop-deleg.md
@@ -276,7 +276,7 @@ The following additional DNS SVCB parameters are defined for the DELEG and SVCB 
 
 The "tlsa" SvcParamKey is a transport parameter representing a TLSA RRset {{?RFC6698}} to be used when connecting to TargetName using a TLS-based transport. If present, this SvcParam SHOULD match the TLSA records whose base domain ({{?RFC6698, Section 3}}) is TargetName. Due to bootstrapping concerns, this SvcParamKey has been added to the DELEG record as the TLSA records might only be resolveable after the initial connection to the delegated nameserver was established. When this field is not present, certificate validation should be performed by either DANE or by traditional TLS certification validation using trusted root certification authorities.
 
-The SvcParamValue is a non-empty value-list.  The presentation and wire format of each value is the same as the presentation and wire format described for the TLSA record as defined in {{?RFC6698}}, sections 2.1 and 2.2 respectively.  To avoid wasting resources in the parent zone, matching type 0 (exact match) MUST NOT be used.
+The SvcParamValue is a non-empty value-list.  The presentation and wire format of each value is the same as the presentation and wire format described for the TLSA record as defined in {{?RFC6698}}, sections 2.1 and 2.2 respectively.  To avoid wasting resources in the parent zone, parents MAY reject RRSets containing "tlsa" SvcParams that use matching type 0 (exact match).
 
 As a special case, the presentation value "disabled", corresponding to an empty value in wire format, indicates that DANE MUST NOT be used with this record.
 


### PR DESCRIPTION
This PR adjusts the SvcParamKeys specified for clarity, internal consistency, and consistency with draft-ietf-add-svcb-dns and draft-ietf-dnsop-svcb-dane.

I believe this change also substantially simplifies the specification while making it more powerful and flexible.